### PR TITLE
:link: Added link to rawsec forensics writeup

### DIFF
--- a/backdoor-ctf-2016/forensics/busybee-150/README.md
+++ b/backdoor-ctf-2016/forensics/busybee-150/README.md
@@ -1,0 +1,19 @@
+# Backdoor CTF : busybee-150
+
+**Category:** Forensics
+**Points:** 150
+**Description:**
+
+> A deadly virus is killing bees in Busybee’s village Busybox, India.
+> Unfortuantely, you have to go to the village to fight the infection.
+> Get the flag virus out of the infected files.
+> Village address: http://hack.bckdr.in/BUSYBEE/infected.tar
+
+
+## Write-up
+
+(TODO)
+
+## Other write-ups and resources
+
+* http://rawsec.ml/en/writeups-forensic-busybee/


### PR DESCRIPTION
This pull request includes the addition of a new directory 'forensics' in the backdoor-ctf-2016 directory. This folder contains a single folder named 'busybee-150' containing a basic README.md with a link the external writeup created by rawsec. This pull solves Issue #1417.