### PR TITLE
Fix links to writeups

### DIFF
--- a/tum-ctf-2016/README.md
+++ b/tum-ctf-2016/README.md
@@ -9,16 +9,16 @@
 
 ## External write-ups only
 
-* [tum-ctf-2016/pwn/l1br4ry-300](tum-ctf-2016/pwn/l1br4ry-300)
-* [tum-ctf-2016/pwn/lolcpp-250](tum-ctf-2016/pwn/lolcpp-250)
-* [tum-ctf-2016/crypto/haggis-100](tum-ctf-2016/crypto/haggis-100)
-* [tum-ctf-2016/web/free-as-in-bavarian-beer-50](tum-ctf-2016/web/free-as-in-bavarian-beer-50)
+* [tum-ctf-2016/pwn/l1br4ry-300](pwn/l1br4ry-300)
+* [tum-ctf-2016/pwn/lolcpp-250](pwn/lolcpp-250)
+* [tum-ctf-2016/crypto/haggis-100](crypto/haggis-100)
+* [tum-ctf-2016/web/free-as-in-bavarian-beer-50](web/free-as-in-bavarian-beer-50)
 * [tum-ctf-2016/web/totp-100](tum-ctf-2016/web/totp-100)
-* [tum-ctf-2016/stego/the-joy-of-paintin-50](tum-ctf-2016/stego/the-joy-of-paintin-50)
-* [tum-ctf-2016/crypto/hiecss-150](tum-ctf-2016/crypto/hiecss-150)
-* [tum-ctf-2016/exploit/c0py-pr073c710n-200](tum-ctf-2016/exploit/c0py-pr073c710n-200)
-* [tum-ctf-2016/pwn/boot-2-brainfuck-150](tum-ctf-2016/pwn/boot-2-brainfuck-150)
-* [tum-ctf-2016/web/f8901da0-300](tum-ctf-2016/web/f8901da0-300)
+* [tum-ctf-2016/stego/the-joy-of-paintin-50](stego/the-joy-of-paintin-50)
+* [tum-ctf-2016/crypto/hiecss-150](crypto/hiecss-150)
+* [tum-ctf-2016/exploit/c0py-pr073c710n-200](exploit/c0py-pr073c710n-200)
+* [tum-ctf-2016/pwn/boot-2-brainfuck-150](pwn/boot-2-brainfuck-150)
+* [tum-ctf-2016/web/f8901da0-300](web/f8901da0-300)
 
 ## Missing write-ups
 


### PR DESCRIPTION
Markdown links are relative to the current directory, not the root of the repository.