### PR TITLE
Change Grehack URL

### DIFF
--- a/grehack-ctf-2016/README.md
+++ b/grehack-ctf-2016/README.md
@@ -1,6 +1,6 @@
 # GreHack CTF 2016 write-ups
 
-* [GreHack.org](https://grehack.org/en/)
+* [GreHack.fr](https://grehack.fr/)
 * [Scoreboard](TODO) or [local alternative](TODOLOCAL)
 
 ## Completed write-ups


### PR DESCRIPTION
The official site is grehack.fr, grehack.org is an unofficial copy